### PR TITLE
fs.copy: copy permissions too

### DIFF
--- a/fs.extra/fs.copy.js
+++ b/fs.extra/fs.copy.js
@@ -30,7 +30,9 @@
             return cb(err);
           }
 
-          fs.utimes(dst, stat.atime, stat.mtime, cb);
+          fs.utimes(dst, stat.atime, stat.mtime, function() {
+              fs.chmod(dst, stat.mode, cb);
+          } );
         });
       });
     }


### PR DESCRIPTION
The documentation for copyRecusrive says:
  Basically a local rsync, uses fs.copy to recursively copy files and folders (with correct permissions).

I don't know if somebody has a different idea than I do of what is correct or if this was just an oversight, but this patch actually makes copy/copyRecursive propagate permissions...
