### PR TITLE
Update license attribute

### DIFF
--- a/fs.extra/package.json
+++ b/fs.extra/package.json
@@ -22,14 +22,5 @@
   "devDependencies": {
     "sequence": "~2.2.1"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license.php"
-    },
-    {
-      "type": "Apache License, Version 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ]
+  "license": "(MIT OR Apache-2.0)"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/